### PR TITLE
Allow alphanumeric for slug

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,7 +8,7 @@ class App < Sinatra::Base
   end
 
   get '/:seed' do
-    srand params[:seed].to_i
+    srand params[:seed].to_i(36)
     primary_color = generate_random_color
     background_color = random_different_color(primary_color)
     @body_color = fillify(primary_color.css_rgba)


### PR DESCRIPTION
Previously, we only allowed numbers as slugs for images. This uses a
base 36 number scheme (26 letters plus 10 digits) to convert
alphanumeric slugs into integers to seed the RNG.
