### PR TITLE
Add a `/random` endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,12 +1,18 @@
 Bundler.require
 require 'yaml'
 require 'digest'
-require 'color/rgb/contrast'
 require_relative 'rng'
 
 class App < Sinatra::Base
   get '/' do
     redirect "/#{SecureRandom.uuid}"
+  end
+
+  get '/random' do
+    generator = Rng.new
+    @avatar = generator.avatar
+
+    erb :index
   end
 
   get '/:seed' do

--- a/rng.rb
+++ b/rng.rb
@@ -1,4 +1,6 @@
 require_relative 'avatar'
+require 'color'
+require 'color/rgb/contrast'
 
 class Rng
   MINUMUM_CONTRAST = 0.4


### PR DESCRIPTION
Previously, we could view a deterministic avatar at `/:seed` or get
redirected to a random `/:seed` page from the root (`/`). To test new
functionality, we would go to `/`, get redirected, view the generated
avatar, and then type in the URL bar again to go back to `/` and restart
the process. This is tedious.

To fix this, I've added a `/random` endpoint that generates a random
avatar and displays it in place. This means we can just keep hitting
refresh to generate a new avatar.

It is important to keep the `/random` action above `/:seed` in the
`app.rb` file, otherwise the router things that `/random` is `/:seed`
where the seed is the string "random". In the future, maybe it makes
sense to namespace `/:seed` under some value such as `/avatars/:seed`.
