### PR TITLE
Add initial pass on diverse body types

### DIFF
--- a/avatar.rb
+++ b/avatar.rb
@@ -1,8 +1,7 @@
 class Avatar
-  attr_reader :body_color, :hair, :hair_color, :background_color, :skin_tone, :glasses, :hair_background, :eyes
+  attr_reader :body_color, :hair, :hair_color, :background_color, :skin_tone, :glasses, :hair_background, :eyes, :body_size
 
-
-  def initialize(body_color, background_color, skin_tone, hair, hair_color, glasses, hair_background, eyes)
+  def initialize(body_color, background_color, skin_tone, hair, hair_color, glasses, hair_background, eyes, body_size)
     @body_color = body_color
     @background_color = background_color
     @skin_tone = skin_tone
@@ -11,6 +10,7 @@ class Avatar
     @glasses = glasses
     @hair_background = hair_background
     @eyes = eyes
+    @body_size = body_size
   end
 
   def shadow_color

--- a/rng.rb
+++ b/rng.rb
@@ -12,7 +12,7 @@ class Rng
   def avatar
     body = color
     background = contrasting_color(color)
-    Avatar.new(body, background, skin_tone, hair, hair_color, glasses, hair_background, eyes)
+    Avatar.new(body, background, skin_tone, hair, hair_color, glasses, hair_background, eyes, body_size)
   end
 
   def contrasting_color(other)
@@ -58,6 +58,10 @@ class Rng
 
   def eyes
     attribute_partial("eyes")
+  end
+
+  def body_size
+    rand(0.85...1.3)
   end
 
   private

--- a/views/index.erb
+++ b/views/index.erb
@@ -6,7 +6,10 @@
     <rect id="bg" fill="<%= @avatar.background_color.css_rgba %>" x="0" y="0" width="200" height="200"/>
     <path id="shadow"  fill="<%= @avatar.shadow_color.css_rgba %>" d="M119,45l81,67l0,88l-97.2,0l16.2,-155Z"/>
     <%= erb @avatar.hair_background rescue nil %>
-    <path id="body" fill="<%= @avatar.body_color.css_rgba %>" d="M126.7,113.4c-3.8,-5 -15.2,-11.4 -26.7,-11.4c-11.4,0 -22.9,6.4 -26.7,11.4c-12.7,16.7 -21,43.2 -21,65.9c0,3 0.4,20.7 0.4,20.7l94.5,0c0,0 0.4,-17.6 0.4,-20.6c0.1,-22.8 -8.3,-49.4 -20.9,-66Z"/>
+    <path id="body"
+      fill="<%= @avatar.body_color.css_rgba %>"
+      d="M126.7,113.4c-3.8,-5 -15.2,-11.4 -26.7,-11.4c-11.4,0 -22.9,6.4 -26.7,11.4c-12.7,16.7 -21,43.2 -21,65.9c0,3 -0.2,17.8 0,20.7c31.767,0 63.533,0 95.3,0c0.3,-2.9 0,-17.6 0,-20.6c0.1,-22.8 -8.3,-49.4 -20.9,-66Z"
+      style="transform-origin: center center; transform: scaleX(<%= @avatar.body_size %>);"/>
     <path id="face" fill="<%= @avatar.skin_tone.css_rgba %>" d="M132.6,74.3c0,12.5-5.7,27-14.4,36.1c-2.6,2.7-10.4,6.2-18.2,6.2s-15.6-3.5-18.2-6.2
        c-8.7-9.1-14.4-23.7-14.4-36.1c0-19.9,14.6-36.1,32.6-36.1S132.6,54.4,132.6,74.3L132.6,74.3z"/>
     <%= erb @avatar.eyes %>


### PR DESCRIPTION
This commit adds a css transform on the body object that will randomize horizontal scaling on the body object.

Eventually I would like to add more bodies but this works for now.

![moo](https://cloud.githubusercontent.com/assets/2489247/26011879/c22a62d4-3720-11e7-950f-2cf038de34a3.gif)
